### PR TITLE
Set `PLUGIN_INSTALL_DIR` as cache entry and fix building FluidSynth opcodes on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,7 +132,7 @@ if(USE_DOUBLE)
     message(STATUS "Building with 64-bit floats")
     if(APPLE)
      set(PLUGIN_INSTALL_DIR
-       "$ENV{HOME}/Library/csound/${APIVERSION}/plugins64")
+       "$ENV{HOME}/Library/csound/${APIVERSION}/plugins64" CACHE PATH "Plugin install path")
     elseif(LINUX)
       set(PLUGIN_INSTALL_DIR
       "${LIBRARY_INSTALL_DIR}/csound/plugins64-${APIVERSION}")
@@ -143,7 +143,7 @@ else()
     message(STATUS "Building with 32-bit floats")
     if(APPLE)
         set(PLUGIN_INSTALL_DIR
-    "$ENV{HOME}/Library/csound/${APIVERSION}/plugins")
+    "$ENV{HOME}/Library/csound/${APIVERSION}/plugins" CACHE PATH "Plugin install path")
     elseif(LINUX)
       set(PLUGIN_INSTALL_DIR
       "${LIBRARY_INSTALL_DIR}/csound/plugins-${APIVERSION}")

--- a/cmake/Modules/FindFLUIDSYNTH.cmake
+++ b/cmake/Modules/FindFLUIDSYNTH.cmake
@@ -19,7 +19,7 @@ find_path (FLUIDSYNTH_INCLUDE_DIR fluidsynth.h)
 endif()
 
 if(APPLE)
-find_library(FLUIDSYNTH_LIBRARY NAMES FluidSynth libfluidsynth HINTS /Library/Frameworks/FluidSynth.framework/
+find_library(FLUIDSYNTH_LIBRARY NAMES FluidSynth fluidsynth HINTS /Library/Frameworks/FluidSynth.framework/
  ${FLUIDSYNTH_LIBRARY_DIR_HINT})
 else()
 find_library (FLUIDSYNTH_LIBRARIES NAMES fluidsynth libfluidsynth)

--- a/cmake/Modules/FindFLUIDSYNTH.cmake
+++ b/cmake/Modules/FindFLUIDSYNTH.cmake
@@ -19,7 +19,7 @@ find_path (FLUIDSYNTH_INCLUDE_DIR fluidsynth.h)
 endif()
 
 if(APPLE)
-find_library(FLUIDSYNTH_LIBRARY NAMES FluidSynth fluidsynth HINTS /Library/Frameworks/FluidSynth.framework/
+find_library(FLUIDSYNTH_LIBRARIES NAMES FluidSynth fluidsynth HINTS /Library/Frameworks/FluidSynth.framework/
  ${FLUIDSYNTH_LIBRARY_DIR_HINT})
 else()
 find_library (FLUIDSYNTH_LIBRARIES NAMES fluidsynth libfluidsynth)

--- a/cmake/Modules/FindFLUIDSYNTH.cmake
+++ b/cmake/Modules/FindFLUIDSYNTH.cmake
@@ -19,7 +19,7 @@ find_path (FLUIDSYNTH_INCLUDE_DIR fluidsynth.h)
 endif()
 
 if(APPLE)
-find_library(FLUIDSYNTH_LIBRARIES NAMES FluidSynth fluidsynth HINTS /Library/Frameworks/FluidSynth.framework/
+find_library(FLUIDSYNTH_LIBRARIES NAMES FluidSynth HINTS /Library/Frameworks/FluidSynth.framework/
  ${FLUIDSYNTH_LIBRARY_DIR_HINT})
 else()
 find_library (FLUIDSYNTH_LIBRARIES NAMES fluidsynth libfluidsynth)

--- a/cmake/Modules/FindFLUIDSYNTH.cmake
+++ b/cmake/Modules/FindFLUIDSYNTH.cmake
@@ -19,7 +19,7 @@ find_path (FLUIDSYNTH_INCLUDE_DIR fluidsynth.h)
 endif()
 
 if(APPLE)
-find_library(FLUIDSYNTH_LIBRARY NAMES FluidSynth HINTS /Library/Frameworks/FluidSynth.framework/
+find_library(FLUIDSYNTH_LIBRARY NAMES FluidSynth libfluidsynth HINTS /Library/Frameworks/FluidSynth.framework/
  ${FLUIDSYNTH_LIBRARY_DIR_HINT})
 else()
 find_library (FLUIDSYNTH_LIBRARIES NAMES fluidsynth libfluidsynth)


### PR DESCRIPTION
This PR sets `PLUGIN_INSTALL_DIR` as a cache entry instead of a hardcoded variable on macOS so that packaging plug-ins is possible using Homebrew (see issue #12).

This also fixes FindFLUIDSYNTH.cmake to use the correct variable name for FluidSynth libraries so FluidSynth opcodes can actually be built on macOS.