### PR TITLE
Use correct Python headers on macOS

### DIFF
--- a/py/src/pythonhelper.h
+++ b/py/src/pythonhelper.h
@@ -23,18 +23,10 @@
 
 #ifdef _DEBUG
 # undef _DEBUG
-#ifdef __APPLE__
-#  include <Python/Python.h>
-#else
 #  include <Python.h>
-#endif
 # define _DEBUG
 #else
-#ifdef __APPLE__
-#  include <Python/Python.h>
-#else
-#  include <Python.h>
-#endif
+# include <Python.h>
 #endif
 
 /*

--- a/py/src/pythonopcodes.c
+++ b/py/src/pythonopcodes.c
@@ -20,20 +20,11 @@
 
 #ifdef _DEBUG
 # undef _DEBUG
-#ifdef __APPLE__
-#  include <Python/Python.h>
-#else
 #  include <Python.h>
-#endif
 # define _DEBUG
 #else
-#ifdef __APPLE__
-#  include <Python/Python.h>
-#else
-#  include <Python.h>
+# include <Python.h>
 #endif
-#endif
-
 #include <sysdep.h>
 #include "csdl.h"
 #include "pythonopcodes.h"

--- a/py/src/pythonopcodes.h
+++ b/py/src/pythonopcodes.h
@@ -23,20 +23,11 @@
 
 #ifdef _DEBUG
 # undef _DEBUG
-#ifdef __APPLE__
-#  include <Python/Python.h>
-#else
 #  include <Python.h>
-#endif
 # define _DEBUG
 #else
-#ifdef __APPLE__
-#  include <Python/Python.h>
-#else
-#  include <Python.h>
+# include <Python.h>
 #endif
-#endif
-
 #include "csdl.h"
 #include "pyx.auto.h"
 #include "pycall.auto.h"


### PR DESCRIPTION
On macOS, `#include <Python/Python.h>` will generally use Python 2 headers that were included with macOS until Monterey 12.3, not Python 3 headers. Python 2 [is no longer included with Monterey 12.3](https://developer.apple.com/documentation/macos-release-notes/macos-12_3-release-notes#Python), so attempting to `#include <Python/Python.h>` now causes compilation of Python opcodes to fail. This pull request uses the correct Python 3 headers on macOS.

This reverts commit 70adf4e016f779ccad374c2616db9d078901106a.